### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ See [Configuration Reference](https://cli.vuejs.org/config/).
 
 ## Run HTTP server
 
-* `npm run start`
+* `npm start`


### PR DESCRIPTION
to tun the start script it isn't necessary to put it as ''' npm run start ''', you can simply put it as "npm start" as start script comes with special privileges in NodeJs